### PR TITLE
Now stub page for clients with extension will return with plaintext mime-type.

### DIFF
--- a/src/main/java/org/moera/node/global/VirtualPageInterceptor.java
+++ b/src/main/java/org/moera/node/global/VirtualPageInterceptor.java
@@ -1,16 +1,16 @@
 package org.moera.node.global;
 
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.moera.node.util.VirtualPageHeader;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
-
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
 @Component
 public class VirtualPageInterceptor extends HandlerInterceptorAdapter {
@@ -36,8 +36,8 @@ public class VirtualPageInterceptor extends HandlerInterceptorAdapter {
 
         if (requestContext.isBrowserExtension()) {
             response.setContentType("text/plain; charset=utf-8");
-            try (OutputStream outputStream = response.getOutputStream()) {
-                outputStream.write("Moera client is loading...".getBytes(StandardCharsets.UTF_8));
+            try (Writer outputStream = new OutputStreamWriter(response.getOutputStream())) {
+                outputStream.write("Moera client is loading...");
             }
             return false;
         }

--- a/src/main/java/org/moera/node/global/VirtualPageInterceptor.java
+++ b/src/main/java/org/moera/node/global/VirtualPageInterceptor.java
@@ -1,16 +1,16 @@
 package org.moera.node.global;
 
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.moera.node.util.VirtualPageHeader;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class VirtualPageInterceptor extends HandlerInterceptorAdapter {
@@ -36,12 +36,9 @@ public class VirtualPageInterceptor extends HandlerInterceptorAdapter {
 
         if (requestContext.isBrowserExtension()) {
             response.setContentType("text/plain; charset=utf-8");
-            Writer out = new OutputStreamWriter(response.getOutputStream());
-            out.write("Moera client is loading.\n"
-                    + "If you are seeing this message for some time now, something is not right.\n"
-                    + "If Moera extension settings are opened, try closing them.\n"
-                    + "It's not helping? Contact developers though github: https://github.com/MoeraOrg/moera-issues\n");
-            out.close();
+            try (OutputStream outputStream = response.getOutputStream()) {
+                outputStream.write("Moera client is loading...".getBytes(StandardCharsets.UTF_8));
+            }
             return false;
         }
 

--- a/src/main/java/org/moera/node/global/VirtualPageInterceptor.java
+++ b/src/main/java/org/moera/node/global/VirtualPageInterceptor.java
@@ -35,16 +35,12 @@ public class VirtualPageInterceptor extends HandlerInterceptorAdapter {
         VirtualPageHeader.put(response, virtualPage.value());
 
         if (requestContext.isBrowserExtension()) {
-            response.setContentType("text/html; charset=utf-8");
+            response.setContentType("text/plain; charset=utf-8");
             Writer out = new OutputStreamWriter(response.getOutputStream());
-            out.write("<!DOCTYPE html>\n"
-                    + "<html>\n"
-                    + "    <head>\n"
-                    + "        <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>\n"
-                    + "        <title>Moera</title>\n"
-                    + "    </head>\n"
-                    + "    <body></body>\n"
-                    + "</html>\n");
+            out.write("Moera client is loading.\n"
+                    + "If you are seeing this message for some time now, something is not right.\n"
+                    + "If Moera extension settings are opened, try closing them.\n"
+                    + "It's not helping? Contact developers though github: https://github.com/MoeraOrg/moera-issues\n");
             out.close();
             return false;
         }


### PR DESCRIPTION
This allows better security and (accidentally) better performance.